### PR TITLE
feat!: updated docker-compose deployment

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -16,12 +16,13 @@ jobs:
           python-version: 3.x
       - run: pip install mkdocs-material==8.*
       - run: mkdocs build --strict --verbose --site-dir=./site
-      # TODO: re-enable once the repo is public
       # - name: build FHIR IG
       #   uses: ghcr.io/miracum/ig-build-tools:v1.0.74@sha256:c33b9cef9076d91f5caa5f4229b0b3591ec8edbfe9986a40b981b1ee6394287c
       #   working-directory: fhir-ig
       #   run: java -jar /usr/local/bin/publisher.jar -ig ig.ini
       # - name: copy FHIR IG output into mkdocs site
       #   run: cp -r fhir-ig/output/ site/fhir
+
+      # TODO: re-enable once the repo is public
       # - run: mkdocs gh-deploy --force
       #   if: github.event_name != 'pull_request'

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -40,7 +40,7 @@
         "assets": [
           {
             "path": "dist/recruit-docker-compose.tar.gz",
-            "label": "Docker Compose deployment files"
+            "label": "Docker Compose deployment bundle"
           }
         ]
       }

--- a/docker-compose/docker-compose.staging.yaml
+++ b/docker-compose/docker-compose.staging.yaml
@@ -13,7 +13,7 @@ services:
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.web.address=:80"
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
     deploy:

--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
     privileged: false
     environment:
       JAEGER_SERVICE_NAME: recruit-query
+      CAMEL_HEALTH_ENABLED: "false"
       FHIR_URL: ${FHIR_URL:?}
       OMOP_JDBCURL: ${OMOP_JDBCURL:?}
       OMOP_USERNAME: ${OMOP_USERNAME:?}

--- a/docs/deployment/docker-compose.md
+++ b/docs/deployment/docker-compose.md
@@ -27,12 +27,7 @@ docker compose --project-name=recruit \
     -f docker-compose/docker-compose.staging.yaml up
 ```
 
-You can run the following to probe every component for its availability/health status:
-
-!!! note
-
-    The query module will only switch to its ready state if it has run at least once,
-    so it may take up to 5 minutes for it to appear healthy.
+You can run the following to probe every component for its health status:
 
 ```sh
 docker compose --project-name=recruit \


### PR DESCRIPTION
BREAKING CHANGES:
    * bind all exposed ports to 127.0.0.1 interface
    * use official OHDSI WebAPI and ATLAS container images
    * added localhost:38084 to CORS allowed origin in WebAPI
    * updated FHIR server to v6.0.1
    * updated postgres DB used by FHIR server to v14.4
    * changed default NOTIFY_MAILER_LINKTEMPLATE to localhost URL
    * set ipc, cap_drop, privileged, and read_only for most services to maximize security
    * added traefik service listening on port 80 and configured all relevant
      services to run on a nip.io local domain
    * only expose list and the staging environment keycloak on a
       localhost port by default. Rest uses traefik